### PR TITLE
Fix tests with additional mocks

### DIFF
--- a/__test__/components/FlashDealsBottomSheet.test.tsx
+++ b/__test__/components/FlashDealsBottomSheet.test.tsx
@@ -28,13 +28,15 @@ jest.mock('expo-linear-gradient', () => { const React=require('react'); const {V
 
 const dispatch = jest.fn();
 (useDispatch as jest.Mock).mockReturnValue(dispatch);
-(useSelector as jest.Mock).mockReturnValue({ restaurant: { flashDealsRestaurants: [], flashDealsLoading: false } });
+const baseState = { restaurant: { flashDealsRestaurants: [], flashDealsLoading: false } };
+(useSelector as jest.Mock).mockImplementation((sel) => sel(baseState));
 
 const noop = () => {};
 
 describe('FlashDealsBottomSheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useSelector as jest.Mock).mockImplementation((sel) => sel(baseState));
   });
 
   it('dispatches fetch when becoming visible', () => {

--- a/__test__/screens/AccountScreen.test.tsx
+++ b/__test__/screens/AccountScreen.test.tsx
@@ -20,7 +20,7 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@expo/vector-icons', () => {
   const React = require('react');
-  return { Ionicons: (p: any) => <icon {...p} /> };
+  return { Ionicons: (p: any) => <icon {...p} />, MaterialCommunityIcons: (p: any) => <icon {...p} /> };
 });
 
 jest.mock('expo-linear-gradient', () => {
@@ -35,9 +35,19 @@ jest.mock('react-native-safe-area-context', () => ({
 
 const dispatch = jest.fn();
 (useDispatch as jest.Mock).mockReturnValue(dispatch);
-(useSelector as jest.Mock).mockImplementation((sel) => sel({
-  user: { name_surname: '', email: '', phoneNumber: '', loading: false, achievements: [] }
-}));
+const baseState = {
+  user: {
+    name_surname: '',
+    email: '',
+    phoneNumber: '',
+    loading: false,
+    achievements: [],
+    rank: 1,
+    totalDiscount: 0,
+    rankLoading: false
+  }
+};
+(useSelector as jest.Mock).mockImplementation((sel) => sel(baseState));
 
 describe('AccountScreen', () => {
   it('dispatches achievements fetch on mount', () => {

--- a/__test__/screens/CartScreen.test.tsx
+++ b/__test__/screens/CartScreen.test.tsx
@@ -3,10 +3,15 @@ import { render } from '@testing-library/react-native';
 import CartScreen from '../../src/features/CartScreen/CartScreen';
 import { useSelector, useDispatch } from 'react-redux';
 import { fetchCart } from '../../src/redux/thunks/cartThunks';
+import { useNavigation } from '@react-navigation/native';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
   useDispatch: jest.fn()
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() })
 }));
 
 jest.mock('../../src/redux/thunks/cartThunks', () => ({
@@ -36,6 +41,7 @@ const baseState = {
   restaurant: {
     restaurantsProximity: [] as any[],
     selectedRestaurantListings: [] as any[],
+    selectedRestaurant: { pickup: true, delivery: true },
     isPickup: true
   }
 };

--- a/__test__/screens/HomeScreen.test.tsx
+++ b/__test__/screens/HomeScreen.test.tsx
@@ -11,7 +11,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn((cb) => cb()),
-  useNavigation: () => ({ navigate: jest.fn() }),
+  useNavigation: () => ({ navigate: jest.fn() })
+}));
+
+jest.mock('@react-navigation/bottom-tabs', () => ({
   createBottomTabNavigator: () => ({
     Navigator: ({ children }: any) => <>{children}</>,
     Screen: ({ children }: any) => <>{children}</>

--- a/__test__/screens/LandingScreen.test.tsx
+++ b/__test__/screens/LandingScreen.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import Landing from '../../src/features/LoginRegister/screens/Landing';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
-jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: () => jest.fn()
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),

--- a/__test__/setup.ts
+++ b/__test__/setup.ts
@@ -9,3 +9,13 @@ jest.mock('expo-secure-store', () => ({
 }));
 // polyfill setImmediate used by Animated
 global.setImmediate = global.setImmediate || ((fn: any, ...args: any[]) => global.setTimeout(fn, 0, ...args));
+// polyfill clearImmediate which is used by some components like StatusBar
+global.clearImmediate = global.clearImmediate || ((id: any) => global.clearTimeout(id));
+
+// Mock expo-haptics to avoid NativeModule errors in tests
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: {},
+  NotificationFeedbackType: {}
+}));

--- a/src/features/Chatbot/ChatbotScreen.tsx
+++ b/src/features/Chatbot/ChatbotScreen.tsx
@@ -405,6 +405,7 @@ const ChatbotScreen: React.FC = () => {
                         style={[styles.sendButton, (!inputText.trim() || isLoading) && styles.disabledButton]}
                         onPress={() => sendMessage(inputText)}
                         disabled={!inputText.trim() || isLoading}
+                        accessibilityRole="button"
                     >
                         {isLoading ? (
                             <ActivityIndicator size="small" color="#FFFFFF"/>


### PR DESCRIPTION
## Summary
- extend jest setup with `clearImmediate` polyfill and expo-haptics mock
- mock `useDispatch` in landing screen tests
- supply navigation mock in cart screen tests
- add state mocks for cart and account screen tests
- mock bottom tab navigator for home screen tests
- expose send button role on chatbot screen

## Testing
- `npm test` *(fails: createBottomTabNavigator not a function etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68424eedf27c8320b80be6eb612798f3